### PR TITLE
Potential fix for code scanning alert no. 7: Exposure of private information

### DIFF
--- a/src/Moongate.Peristence/Services/MemoryPackPersistenceManager.cs
+++ b/src/Moongate.Peristence/Services/MemoryPackPersistenceManager.cs
@@ -270,10 +270,10 @@ public class MemoryPackPersistenceManager : IPersistenceManager
         }
 
         _logger.Information(
-            "Successfully loaded {TotalEntities} entities across {TypeCount} types from {FilePath}",
+            "Successfully loaded {TotalEntities} entities across {TypeCount} types from file {FileName}",
             result.Sum(kvp => kvp.Value.Count),
             result.Count,
-            filePath
+            Path.GetFileName(filePath)
         );
 
         return result;


### PR DESCRIPTION
Potential fix for [https://github.com/Moongate-server/Moongate/security/code-scanning/7](https://github.com/Moongate-server/Moongate/security/code-scanning/7)

To address the issue, the `filePath` variable should be sanitized or masked before being logged. This ensures that sensitive components of the path (e.g., user-specific directories) are not exposed in the logs. A common approach is to log only the filename or a generic representation of the path, omitting sensitive directory information.

The fix involves modifying the logging statement on line 276 in `MemoryPackPersistenceManager.cs` to exclude sensitive parts of `filePath`. This can be achieved by extracting only the filename using `Path.GetFileName(filePath)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
